### PR TITLE
fix(frontend): Make anchor links accessible, esp. on mobile

### DIFF
--- a/apps/frontend/app/layout/toaster.tsx
+++ b/apps/frontend/app/layout/toaster.tsx
@@ -4,13 +4,13 @@ import { CircleCheckIcon } from "~/components/icons";
 
 export function Toaster() {
   return (
-    <ReactHotToaster containerClassName="mt-8">
+    <ReactHotToaster containerClassName="mt-12" position="top-center">
       {(t) => (
         <Transition
           appear
           show={t.visible}
           as="div"
-          className="flex transform items-center gap-1 rounded bg-zinc-900/80 px-3 py-2 text-sm font-medium text-zinc-50 shadow-md dark:bg-zinc-600/80"
+          className="flex transform items-center gap-1 rounded bg-zinc-900/80 px-3 py-2 text-sm font-medium text-zinc-50 shadow-md backdrop-blur-xs dark:bg-zinc-50/80 dark:text-zinc-900"
           enter="transition-all duration-150"
           enterFrom="opacity-0 scale-50"
           enterTo="opacity-100 scale-100"
@@ -18,7 +18,7 @@ export function Toaster() {
           leaveFrom="opacity-100 scale-100"
           leaveTo="opacity-0 scale-75"
         >
-          <CircleCheckIcon className="h-5 w-5 text-green-300" />
+          <CircleCheckIcon className="h-5 w-5 text-teal-400 dark:text-teal-600" />
           {resolveValue(t.message, t)}
         </Transition>
       )}

--- a/apps/frontend/app/root.tsx
+++ b/apps/frontend/app/root.tsx
@@ -79,7 +79,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 export function Layout({ children }: { children: React.ReactNode }) {
   const { header, footer, environment } = useLoaderData<typeof loader>();
   return (
-    <html lang="en" className="h-full antialiased">
+    <html lang="en" className="h-full scroll-pt-6 antialiased">
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/apps/frontend/app/routes/post/headings.tsx
+++ b/apps/frontend/app/routes/post/headings.tsx
@@ -63,12 +63,7 @@ function PostHeading({
 }) {
   const ref = useRef<HTMLHeadingElement>(null);
   return (
-    <HeadingElement
-      {...props}
-      ref={ref}
-      id={id}
-      className="flex items-center gap-1.5"
-    >
+    <HeadingElement {...props} ref={ref} id={id}>
       {id ? (
         <AnchorLink targetId={id} targetRef={ref}>
           {children}
@@ -102,12 +97,12 @@ function AnchorLink({
         await navigator.clipboard.writeText(location.href);
         toast.success("Link copied to clipboard");
       }}
-      className="not-prose group flex items-center gap-1.5"
+      className="not-prose group block"
       href={`#${targetId}`}
       title="Copy link to this section"
     >
       {children}
-      <LinkIcon className="hidden h-6 w-6 text-zinc-800 group-hover:inline dark:text-zinc-300" />
+      <LinkIcon className="-mt-1 ml-1.5 hidden h-6 w-6 text-zinc-800 group-hover:inline dark:text-zinc-300" />
     </a>
   );
 }

--- a/apps/frontend/app/routes/post/headings.tsx
+++ b/apps/frontend/app/routes/post/headings.tsx
@@ -3,6 +3,7 @@ import {
   type HTMLAttributes,
   useRef,
   type RefObject,
+  type ReactNode,
 } from "react";
 import toast from "react-hot-toast";
 import { LinkIcon } from "~/components/icons";
@@ -66,10 +67,15 @@ function PostHeading({
       {...props}
       ref={ref}
       id={id}
-      className="group flex items-center"
+      className="flex items-center gap-1.5"
     >
-      {children}
-      {id && <AnchorLink targetId={id} targetRef={ref} />}
+      {id ? (
+        <AnchorLink targetId={id} targetRef={ref}>
+          {children}
+        </AnchorLink>
+      ) : (
+        children
+      )}
     </HeadingElement>
   );
 }
@@ -77,9 +83,11 @@ function PostHeading({
 function AnchorLink({
   targetRef,
   targetId,
+  children,
 }: {
   targetId: string;
   targetRef: RefObject<Element | null>;
+  children: ReactNode;
 }) {
   return (
     <a
@@ -94,11 +102,12 @@ function AnchorLink({
         await navigator.clipboard.writeText(location.href);
         toast.success("Link copied to clipboard");
       }}
-      className="invisible ml-1.5 inline-block text-zinc-500 group-hover:visible hover:text-zinc-600 dark:text-zinc-400 dark:hover:text-zinc-300"
+      className="not-prose group flex items-center gap-1.5"
       href={`#${targetId}`}
       title="Copy link to this section"
     >
-      <LinkIcon className="h-6 w-6" />
+      {children}
+      <LinkIcon className="hidden h-6 w-6 text-zinc-800 group-hover:inline dark:text-zinc-300" />
     </a>
   );
 }


### PR DESCRIPTION
- Full heading is now clickable
- Not relying on hover anymore to make the link available, therefore now accessible on mobile devices
- Added top scroll padding to improve scroll experience
- Refined colors

Closes #60 