### PR TITLE
chore(fly): set autostop to suspend

### DIFF
--- a/apps/cms/fly.template.toml
+++ b/apps/cms/fly.template.toml
@@ -8,7 +8,7 @@ primary_region = '$FLY_PRIMARY_REGION'
 [http_service]
   internal_port = 3001
   force_https = true
-  auto_stop_machines = true
+  auto_stop_machines = "suspend"
   auto_start_machines = true
   min_machines_running = $FLY_MIN_MACHINES_RUNNING
   processes = ['app']

--- a/apps/frontend/fly.template.toml
+++ b/apps/frontend/fly.template.toml
@@ -8,7 +8,7 @@ primary_region = '$FLY_PRIMARY_REGION'
 [http_service]
   internal_port = 3000
   force_https = true
-  auto_stop_machines = true
+  auto_stop_machines = "suspend"
   auto_start_machines = true
   min_machines_running = $FLY_MIN_MACHINES_RUNNING
   processes = ['app']


### PR DESCRIPTION
## Summary
- Configure CMS and Frontend Fly templates to autosuspend idle Machines instead of stopping them.
- Keep autostart and existing minimum machine settings unchanged.

## Impact
- Idle Fly Machines should resume from suspend rather than cold start from stopped state when supported by Fly.

## Validation
- `rg -n "auto_stop_machines" apps/cms apps/frontend`