### PR TITLE
fix(frontend): add RSS item images

### DIFF
--- a/apps/frontend/app/routes/rss/route.test.ts
+++ b/apps/frontend/app/routes/rss/route.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+import { getMeta, getPosts, tryGetPage } from "~/utils/cms-data.server";
+import { loader } from "./route";
+
+vi.mock("~/utils/cms-data.server", () => ({
+  getMeta: vi.fn(),
+  getPosts: vi.fn(),
+  tryGetPage: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.mocked(getMeta).mockResolvedValue({
+    siteName: "fxmk.dev",
+  } as Awaited<ReturnType<typeof getMeta>>);
+  vi.mocked(tryGetPage).mockResolvedValue({
+    meta: {
+      description: "Articles",
+      image: {
+        filename: "articles-cover.jpg",
+        mimeType: "image/jpeg",
+      },
+    },
+  } as Awaited<ReturnType<typeof tryGetPage>>);
+  vi.mocked(getPosts).mockResolvedValue([
+    {
+      title: "Post with image",
+      content_summary: "Summary",
+      publishedAt: "2026-05-22T10:00:00.000Z",
+      slug: "post-with-image",
+      meta: {
+        image: {
+          filename: "post-cover.jpg",
+          mimeType: "image/jpeg",
+        },
+      },
+    },
+    {
+      title: "Post without image",
+      content_summary: "No image",
+      publishedAt: "2026-05-21T10:00:00.000Z",
+      slug: "post-without-image",
+      meta: {},
+    },
+  ] as Awaited<ReturnType<typeof getPosts>>);
+
+  process.env.CANONICAL_HOSTNAME = "fxmk.dev";
+  process.env.IMAGEKIT_BASE_URL = "https://ik.imagekit.io/fxmk";
+});
+
+test("adds Media RSS image tags for posts with SEO images", async () => {
+  const response = await loader({
+    request: new Request("https://example.com/articles/rss.xml"),
+  } as Parameters<typeof loader>[0]);
+  const content = await response.text();
+
+  expect(getPosts).toHaveBeenCalledWith(1);
+  expect(content).toContain('xmlns:media="http://search.yahoo.com/mrss/"');
+  expect(content).toContain(
+    '<media:content url="https://ik.imagekit.io/fxmk/post-cover.jpg?tr=w-1200,h-630" medium="image" type="image/jpeg" width="1200" height="630" />',
+  );
+  expect(content).toContain(
+    '<media:thumbnail url="https://ik.imagekit.io/fxmk/post-cover.jpg?tr=w-1200,h-630" width="1200" height="630" />',
+  );
+  expect(content.match(/<media:content/g)).toHaveLength(1);
+  expect(content.match(/<media:thumbnail/g)).toHaveLength(1);
+});

--- a/apps/frontend/app/routes/rss/route.ts
+++ b/apps/frontend/app/routes/rss/route.ts
@@ -4,17 +4,21 @@ import { getMeta, getPosts, tryGetPage } from "~/utils/cms-data.server";
 import { parseISO, format } from "date-fns";
 import { getSocialImageUrl } from "~/utils/page-meta";
 import { getEnvironment } from "~/utils/environment.server";
+import type { Media, Post } from "@fxmk/payload-types";
 
 const rssDateFormat = "eee, dd MMM yyyy HH:mm:ss xx";
+const rssImageWidth = 1200;
+const rssImageHeight = 630;
 
 export async function loader({ request }: Route.LoaderArgs) {
   const [meta, page, posts] = await Promise.all([
     getMeta(),
     tryGetPage("/articles"),
-    getPosts(),
+    getPosts(1),
   ]);
 
   if (!page) throw new Response(null, { status: 404, statusText: "Not Found" });
+  const environment = getEnvironment(request);
 
   const channelLastChanged = posts
     .map((p) => p.publishedAt)
@@ -22,7 +26,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     .map((d) => format(parseISO(d!), rssDateFormat));
 
   const content = `<?xml version="1.0" encoding="UTF-8"?>
-     <rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:webfeeds="http://webfeeds.org/rss/1.0" version="2.0">
+     <rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" xmlns:webfeeds="http://webfeeds.org/rss/1.0" version="2.0">
        <channel>
          <title>${meta.siteName ?? ""}</title>
          <link>${getCanonicalUrl(request, "/articles")}</link>
@@ -31,21 +35,23 @@ export async function loader({ request }: Route.LoaderArgs) {
          <ttl>60</ttl>
          <lastBuildDate>${channelLastChanged}</lastBuildDate>
          <atom:link href="${getCanonicalRequestUrl(request)}" rel="self" type="application/rss+xml" />
-         <webfeeds:cover image="${getSocialImageUrl(page.meta!, 2400, 1260, getEnvironment(request))}" />
+         <webfeeds:cover image="${getSocialImageUrl(page.meta!, 2400, 1260, environment)}" />
          <webfeeds:icon>${getCanonicalUrl(request, "/favicon-96x96.png")}</webfeeds:icon>
          <webfeeds:logo>${getCanonicalUrl(request, "/favicon.svg")}</webfeeds:logo>
          <webfeeds:accentColor>#2dd4bf</webfeeds:accentColor>
          ${posts
-           .map(
-             ({ title, content_summary, publishedAt, slug }) => `
+           .map((post) => {
+             const { title, content_summary, publishedAt, slug } = post;
+             return `
            <item>
              <title>${cdata(title)}</title>
              <description>${cdata(content_summary ?? "")}</description>
              ${publishedAt ? `<pubDate>${format(parseISO(publishedAt), rssDateFormat)}</pubDate>` : ""}
              <link>${getCanonicalUrl(request, `/articles/${slug}`)}</link>
              <guid>${getCanonicalUrl(request, `/articles/${slug}`)}</guid>
-           </item>`,
-           )
+             ${getItemImageTags(post, environment)}
+           </item>`;
+           })
            .join("")}
        </channel>
      </rss>`;
@@ -66,4 +72,27 @@ function getCanonicalUrl(request: Request, pathname: string) {
 
 function cdata(s: string) {
   return `<![CDATA[${s}]]>`;
+}
+
+function getItemImageTags(
+  post: Post,
+  environment: ReturnType<typeof getEnvironment>,
+) {
+  const image = post.meta?.image;
+  if (!isMedia(image)) return "";
+
+  const imageUrl = getSocialImageUrl(
+    { image },
+    rssImageWidth,
+    rssImageHeight,
+    environment,
+  );
+  const type = image.mimeType ?? "";
+
+  return `<media:content url="${imageUrl}" medium="image" type="${type}" width="${rssImageWidth}" height="${rssImageHeight}" />
+             <media:thumbnail url="${imageUrl}" width="${rssImageWidth}" height="${rssImageHeight}" />`;
+}
+
+function isMedia(image: Media | string | null | undefined): image is Media {
+  return typeof image === "object" && !!image?.filename;
 }

--- a/apps/frontend/app/utils/cms-data.server.ts
+++ b/apps/frontend/app/utils/cms-data.server.ts
@@ -193,9 +193,10 @@ export async function getPages() {
     .docs as Page[];
 }
 
-export async function getPosts() {
-  return (await loadData(`posts`, 0, { "where[_status][equals]": "published" }))
-    .docs as Post[];
+export async function getPosts(depth = 0) {
+  return (
+    await loadData(`posts`, depth, { "where[_status][equals]": "published" })
+  ).docs as Post[];
 }
 
 export async function tryGetRedirect(pathname: string) {


### PR DESCRIPTION
## Problem

Feed readers such as Feedly need item-level image hints to show a preview image for each RSS entry. The existing feed only exposed channel-level WebFeeds imagery, so individual posts did not carry their SEO/Open Graph image into the RSS item metadata.

## Summary

- add Media RSS item image tags to each article feed item when a post has an SEO image
- load RSS posts with enough CMS depth to access each post's SEO image
- keep existing channel-level WebFeeds cover, icon, logo, and accent metadata
- cover the image/no-image RSS behavior with a focused Vitest test

Closes #31

## Validation

- `pnpm --filter @fxmk/frontend exec vitest run app/routes/rss/route.test.ts`
- `pnpm --filter @fxmk/frontend typecheck`
- `pnpm --filter @fxmk/frontend exec prettier --check app/routes/rss/route.ts app/routes/rss/route.test.ts app/utils/cms-data.server.ts`
- `pnpm --filter @fxmk/frontend exec eslint app/routes/rss/route.ts app/routes/rss/route.test.ts app/utils/cms-data.server.ts --max-warnings=0`

## Risks and Mitigations

- Feed-reader behavior can vary by client; this uses standard Media RSS tags without adding RSS enclosures that require exact byte lengths.
- Posts without an SEO image intentionally omit item-level image tags, preserving current behavior for incomplete metadata.
- The wider RSS route still builds XML manually; this PR keeps the change scoped and adds regression coverage for the new image metadata.

## Follow-ups

- None required for this fix.
