### PR TITLE
feat(frontend): optimize responsive images

### DIFF
--- a/apps/frontend/app/components/media-image.tsx
+++ b/apps/frontend/app/components/media-image.tsx
@@ -49,9 +49,18 @@ function useImageSources(
   const sources = useMemo(
     () =>
       imageMeta?.filename
-        ? imagekitImageSources(imagekitBaseUrl, imageMeta.filename, crop)
+        ? imagekitImageSources(imagekitBaseUrl, imageMeta.filename, crop, {
+            width: imageMeta.width,
+            height: imageMeta.height,
+          })
         : null,
-    [crop, imageMeta?.filename, imagekitBaseUrl],
+    [
+      crop,
+      imageMeta?.filename,
+      imageMeta?.height,
+      imageMeta?.width,
+      imagekitBaseUrl,
+    ],
   );
 
   return sources;

--- a/apps/frontend/app/components/media-image.tsx
+++ b/apps/frontend/app/components/media-image.tsx
@@ -2,34 +2,37 @@ import { mediaImageSizes } from "@fxmk/shared";
 import { type Media } from "@fxmk/payload-types";
 import { useEnvironment } from "../utils/environment";
 import { useMemo } from "react";
-import { imagekitUrl } from "~/utils/imagekit";
+import { imagekitImageSources, type ImageCrop } from "~/utils/imagekit";
 
 type MediaImageProps = {
   media: Media | string;
   preferredSize: ImageSize;
+  crop?: ImageCrop;
 } & Omit<
   React.DetailedHTMLProps<
     React.ImgHTMLAttributes<HTMLImageElement>,
     HTMLImageElement
   >,
-  "alt" | "src"
+  "alt" | "src" | "srcSet"
 >;
 
 export function MediaImage({
   media,
   preferredSize = "large",
+  crop,
   ...props
 }: MediaImageProps) {
   if (typeof media !== "object") return null;
 
   const imageMeta = selectImageFromMedia(media, preferredSize);
 
-  const src = useImageSrc(imageMeta);
-  if (!src) return null;
+  const sources = useImageSources(imageMeta, crop);
+  if (!sources) return null;
 
   return (
     <img
-      src={src}
+      src={sources.src}
+      srcSet={sources.srcSet}
       alt={media.alt ?? undefined}
       width={imageMeta.width ?? undefined}
       height={imageMeta.height ?? undefined}
@@ -38,20 +41,23 @@ export function MediaImage({
   );
 }
 
-function useImageSrc(imageMeta: ImageMeta | undefined | null) {
+function useImageSources(
+  imageMeta: ImageMeta | undefined | null,
+  crop: ImageCrop | undefined,
+) {
   const { imagekitBaseUrl } = useEnvironment();
-  const src = useMemo(
+  const sources = useMemo(
     () =>
       imageMeta?.filename
-        ? imagekitUrl(imagekitBaseUrl, imageMeta.filename)
+        ? imagekitImageSources(imagekitBaseUrl, imageMeta.filename, crop)
         : null,
-    [imageMeta?.filename, imagekitBaseUrl],
+    [crop, imageMeta?.filename, imagekitBaseUrl],
   );
 
-  return src;
+  return sources;
 }
 
-function selectImageFromMedia(media: Media, preferredSize: ImageSize) {
+export function selectImageFromMedia(media: Media, preferredSize: ImageSize) {
   if (!media.sizes) return media;
 
   const preferredSizeInfo = mediaImageSizes.find(

--- a/apps/frontend/app/components/media-image.tsx
+++ b/apps/frontend/app/components/media-image.tsx
@@ -1,8 +1,8 @@
-import { mediaImageSizes } from "@fxmk/shared";
 import { type Media } from "@fxmk/payload-types";
 import { useEnvironment } from "../utils/environment";
 import { useMemo } from "react";
 import { imagekitImageSources, type ImageCrop } from "~/utils/imagekit";
+import { selectImageFromMedia } from "~/utils/media-image";
 
 type MediaImageProps = {
   media: Media | string;
@@ -55,49 +55,6 @@ function useImageSources(
   );
 
   return sources;
-}
-
-export function selectImageFromMedia(media: Media, preferredSize: ImageSize) {
-  if (!media.sizes) return media;
-
-  const preferredSizeInfo = mediaImageSizes.find(
-    (s) => s.name === preferredSize,
-  );
-  if (!preferredSizeInfo) {
-    throw new Error(`Invalid preferredSize '${preferredSize}'`);
-  }
-
-  if (
-    media.width &&
-    preferredSizeInfo.width &&
-    media.width <= preferredSizeInfo.width
-  ) {
-    // original is smaller or same as the preferred size, return original
-    return media;
-  }
-
-  // use preferredSize or next available larger size (to avoid returning a too big original if preferredSize was not generated)
-  const preferredSizeIndex = mediaImageSizes.indexOf(preferredSizeInfo);
-  for (
-    let index = preferredSizeIndex;
-    index < mediaImageSizes.length;
-    index++
-  ) {
-    const size = mediaImageSizes[index].name as ImageSize;
-
-    const image = media.sizes[size];
-    if (image && image.filename) return image;
-  }
-
-  // if no larger size is available, return the next smaller size
-  for (let index = preferredSizeIndex - 1; index >= 0; index--) {
-    const size = mediaImageSizes[index].name as ImageSize;
-
-    const image = media.sizes[size];
-    if (image && image.filename) return image;
-  }
-
-  return media;
 }
 
 export type ImageSize = keyof NonNullable<Media["sizes"]>;

--- a/apps/frontend/app/layout/header.tsx
+++ b/apps/frontend/app/layout/header.tsx
@@ -160,6 +160,7 @@ function Avatar({
         media={avatar}
         preferredSize="thumbnail"
         sizes={large ? "4rem" : "2.25rem"}
+        crop={{ aspectRatio: 1, widths: large ? [64, 128] : [36, 72] }}
         className={clsx(
           "rounded-full bg-zinc-100 object-cover dark:bg-zinc-800",
           large ? "h-16 w-16" : "h-9 w-9",

--- a/apps/frontend/app/routes/page/about.tsx
+++ b/apps/frontend/app/routes/page/about.tsx
@@ -19,6 +19,7 @@ export function About({ richText, portraitImage, links }: AboutBlock) {
                 media={portraitImage}
                 sizes="(min-width: 1024px) 32rem, 20rem"
                 preferredSize="large"
+                crop={{ aspectRatio: 1, widths: [320, 640, 1024] }}
                 className="aspect-square rotate-3 rounded-2xl bg-zinc-100 object-cover dark:bg-zinc-800"
               />
             </div>

--- a/apps/frontend/app/routes/page/photos.tsx
+++ b/apps/frontend/app/routes/page/photos.tsx
@@ -28,6 +28,7 @@ export function Photos({ photos }: PhotosProps) {
               media={photo.image}
               preferredSize="small"
               sizes="(min-width: 640px) 18rem, 11rem"
+              crop={{ aspectRatio: 9 / 10, widths: [176, 352, 288, 576] }}
               className="absolute inset-0 h-full w-full object-cover"
             />
           </div>

--- a/apps/frontend/app/utils/imagekit.test.ts
+++ b/apps/frontend/app/utils/imagekit.test.ts
@@ -1,6 +1,12 @@
 import { expect, test } from "vitest";
+import type { Media } from "@fxmk/payload-types";
 
-import { imagekitUrl } from "./imagekit";
+import { selectImageFromMedia } from "../components/media-image";
+import {
+  imageCropTransformation,
+  imagekitImageSources,
+  imagekitUrl,
+} from "./imagekit";
 
 test("builds an ImageKit URL for a plain path", () => {
   expect(imagekitUrl("https://ik.imagekit.io/demo", "folder/photo.jpg")).toBe(
@@ -15,3 +21,76 @@ test("builds an ImageKit URL with transformations", () => {
     ]),
   ).toBe("https://ik.imagekit.io/demo/folder/photo.jpg?tr=w-1200,h-630");
 });
+
+test("builds responsive cropped ImageKit sources", () => {
+  expect(
+    imagekitImageSources("https://ik.imagekit.io/demo", "folder/photo.jpg", {
+      aspectRatio: 1,
+      widths: [300, 150, 300],
+    }),
+  ).toEqual({
+    src: "https://ik.imagekit.io/demo/folder/photo.jpg?tr=w-300,h-300,c-maintain_ratio,fo-center",
+    srcSet:
+      "https://ik.imagekit.io/demo/folder/photo.jpg?tr=w-150,h-150,c-maintain_ratio,fo-center 150w, https://ik.imagekit.io/demo/folder/photo.jpg?tr=w-300,h-300,c-maintain_ratio,fo-center 300w",
+  });
+});
+
+test("calculates crop height from aspect ratio", () => {
+  expect(imageCropTransformation(9 / 10, 288)).toMatchObject({
+    width: "288",
+    height: "320",
+    crop: "maintain_ratio",
+    focus: "center",
+  });
+});
+
+test("selects the preferred generated Payload image size", () => {
+  const image = selectImageFromMedia(
+    media({
+      filename: "original.jpg",
+      width: 2400,
+      sizes: {
+        medium: { filename: "medium.jpg", width: 900 },
+        large: { filename: "large.jpg", width: 1400 },
+      },
+    }),
+    "medium",
+  );
+
+  expect(image).toMatchObject({ filename: "medium.jpg" });
+});
+
+test("selects the next larger Payload image size when preferred is missing", () => {
+  const image = selectImageFromMedia(
+    media({
+      filename: "original.jpg",
+      width: 2400,
+      sizes: {
+        thumbnail: { filename: "thumbnail.jpg", width: 300 },
+        medium: { filename: "medium.jpg", width: 900 },
+      },
+    }),
+    "small",
+  );
+
+  expect(image).toMatchObject({ filename: "medium.jpg" });
+});
+
+test("uses the original image when it is not larger than the preferred size", () => {
+  const image = selectImageFromMedia(
+    media({
+      filename: "original.jpg",
+      width: 500,
+      sizes: {
+        small: { filename: "small.jpg", width: 600 },
+      },
+    }),
+    "small",
+  );
+
+  expect(image).toMatchObject({ filename: "original.jpg" });
+});
+
+function media(value: Partial<Media>) {
+  return value as Media;
+}

--- a/apps/frontend/app/utils/imagekit.test.ts
+++ b/apps/frontend/app/utils/imagekit.test.ts
@@ -34,6 +34,42 @@ test("builds responsive cropped ImageKit sources", () => {
   });
 });
 
+test("clamps cropped ImageKit sources to source image width", () => {
+  expect(
+    imagekitImageSources(
+      "https://ik.imagekit.io/demo",
+      "folder/photo.jpg",
+      {
+        aspectRatio: 1,
+        widths: [320, 640, 1024],
+      },
+      { width: 500 },
+    ),
+  ).toEqual({
+    src: "https://ik.imagekit.io/demo/folder/photo.jpg?tr=w-500,h-500,c-maintain_ratio,fo-center",
+    srcSet:
+      "https://ik.imagekit.io/demo/folder/photo.jpg?tr=w-320,h-320,c-maintain_ratio,fo-center 320w, https://ik.imagekit.io/demo/folder/photo.jpg?tr=w-500,h-500,c-maintain_ratio,fo-center 500w",
+  });
+});
+
+test("clamps cropped ImageKit sources to source image height", () => {
+  expect(
+    imagekitImageSources(
+      "https://ik.imagekit.io/demo",
+      "folder/photo.jpg",
+      {
+        aspectRatio: 1,
+        widths: [320, 500],
+      },
+      { width: 500, height: 300 },
+    ),
+  ).toEqual({
+    src: "https://ik.imagekit.io/demo/folder/photo.jpg?tr=w-300,h-300,c-maintain_ratio,fo-center",
+    srcSet:
+      "https://ik.imagekit.io/demo/folder/photo.jpg?tr=w-300,h-300,c-maintain_ratio,fo-center 300w",
+  });
+});
+
 test("calculates crop height from aspect ratio", () => {
   expect(imageCropTransformation(9 / 10, 288)).toMatchObject({
     width: "288",

--- a/apps/frontend/app/utils/imagekit.test.ts
+++ b/apps/frontend/app/utils/imagekit.test.ts
@@ -1,12 +1,11 @@
 import { expect, test } from "vitest";
-import type { Media } from "@fxmk/payload-types";
 
-import { selectImageFromMedia } from "../components/media-image";
 import {
   imageCropTransformation,
   imagekitImageSources,
   imagekitUrl,
 } from "./imagekit";
+import { selectImageFromMedia } from "./media-image";
 
 test("builds an ImageKit URL for a plain path", () => {
   expect(imagekitUrl("https://ik.imagekit.io/demo", "folder/photo.jpg")).toBe(
@@ -91,6 +90,6 @@ test("uses the original image when it is not larger than the preferred size", ()
   expect(image).toMatchObject({ filename: "original.jpg" });
 });
 
-function media(value: Partial<Media>) {
-  return value as Media;
+function media(value: Parameters<typeof selectImageFromMedia>[0]) {
+  return value;
 }

--- a/apps/frontend/app/utils/imagekit.ts
+++ b/apps/frontend/app/utils/imagekit.ts
@@ -5,6 +5,11 @@ export type ImageCrop = {
   widths: number[];
 };
 
+export type ImageCropSource = {
+  width?: number | null;
+  height?: number | null;
+};
+
 export function imagekitUrl(
   urlEndpoint: string,
   filename: string,
@@ -21,6 +26,7 @@ export function imagekitImageSources(
   urlEndpoint: string,
   filename: string,
   crop?: ImageCrop,
+  source?: ImageCropSource,
 ) {
   if (!crop) {
     return {
@@ -28,7 +34,10 @@ export function imagekitImageSources(
     };
   }
 
-  const widths = normalizeWidths(crop.widths);
+  const widths = normalizeWidths(
+    crop.widths,
+    getMaxCropWidth(crop.aspectRatio, source),
+  );
   if (widths.length === 0) {
     return {
       src: imagekitUrl(urlEndpoint, filename),
@@ -66,8 +75,29 @@ export function imageCropTransformation(
   };
 }
 
-function normalizeWidths(widths: number[]) {
-  return [...new Set(widths.map(Math.round).filter((width) => width > 0))].sort(
-    (a, b) => a - b,
-  );
+function normalizeWidths(widths: number[], maxWidth?: number) {
+  return [
+    ...new Set(
+      widths
+        .map(Math.round)
+        .filter((width) => width > 0)
+        .map((width) => (maxWidth ? Math.min(width, maxWidth) : width)),
+    ),
+  ].sort((a, b) => a - b);
+}
+
+function getMaxCropWidth(aspectRatio: number, source?: ImageCropSource) {
+  const maxWidths = [
+    source?.width ?? undefined,
+    source?.height && aspectRatio > 0
+      ? Math.floor(source.height * aspectRatio)
+      : undefined,
+  ]
+    .filter((width): width is number => typeof width === "number" && width > 0)
+    .map(Math.floor)
+    .filter((width) => width > 0);
+
+  if (maxWidths.length === 0) return undefined;
+
+  return Math.min(...maxWidths);
 }

--- a/apps/frontend/app/utils/imagekit.ts
+++ b/apps/frontend/app/utils/imagekit.ts
@@ -1,5 +1,10 @@
 import { buildSrc, type Transformation } from "@imagekit/javascript";
 
+export type ImageCrop = {
+  aspectRatio: number;
+  widths: number[];
+};
+
 export function imagekitUrl(
   urlEndpoint: string,
   filename: string,
@@ -10,4 +15,59 @@ export function imagekitUrl(
     src: filename,
     transformation,
   });
+}
+
+export function imagekitImageSources(
+  urlEndpoint: string,
+  filename: string,
+  crop?: ImageCrop,
+) {
+  if (!crop) {
+    return {
+      src: imagekitUrl(urlEndpoint, filename),
+    };
+  }
+
+  const widths = normalizeWidths(crop.widths);
+  if (widths.length === 0) {
+    return {
+      src: imagekitUrl(urlEndpoint, filename),
+    };
+  }
+
+  const srcSet = widths
+    .map((width) => {
+      const transformation = imageCropTransformation(crop.aspectRatio, width);
+      return `${imagekitUrl(urlEndpoint, filename, [transformation])} ${width}w`;
+    })
+    .join(", ");
+
+  return {
+    src: imagekitUrl(urlEndpoint, filename, [
+      imageCropTransformation(crop.aspectRatio, widths[widths.length - 1]),
+    ]),
+    srcSet,
+  };
+}
+
+export function imageCropTransformation(
+  aspectRatio: number,
+  width: number,
+): Transformation {
+  if (aspectRatio <= 0) {
+    throw new Error(`Invalid crop aspect ratio '${aspectRatio}'`);
+  }
+
+  return {
+    width: width.toString(),
+    height: Math.round(width / aspectRatio).toString(),
+    crop: "maintain_ratio",
+    focus: "center",
+  };
+}
+
+function normalizeWidths(widths: number[]) {
+  return [...new Set(widths.map(Math.round).filter((width) => width > 0))].sort(
+    (a, b) => a - b,
+  );
 }

--- a/apps/frontend/app/utils/media-image.ts
+++ b/apps/frontend/app/utils/media-image.ts
@@ -1,0 +1,57 @@
+import { mediaImageSizes } from "@fxmk/shared";
+
+type ImageMeta = {
+  filename?: string | null;
+  width?: number | null;
+  height?: number | null;
+};
+
+type MediaWithSizes = ImageMeta & {
+  sizes?: Partial<Record<string, ImageMeta>> | null;
+};
+
+export function selectImageFromMedia(
+  media: MediaWithSizes,
+  preferredSize: string,
+) {
+  if (!media.sizes) return media;
+
+  const preferredSizeInfo = mediaImageSizes.find(
+    (s) => s.name === preferredSize,
+  );
+  if (!preferredSizeInfo) {
+    throw new Error(`Invalid preferredSize '${preferredSize}'`);
+  }
+
+  if (
+    media.width &&
+    preferredSizeInfo.width &&
+    media.width <= preferredSizeInfo.width
+  ) {
+    // original is smaller or same as the preferred size, return original
+    return media;
+  }
+
+  // use preferredSize or next available larger size (to avoid returning a too big original if preferredSize was not generated)
+  const preferredSizeIndex = mediaImageSizes.indexOf(preferredSizeInfo);
+  for (
+    let index = preferredSizeIndex;
+    index < mediaImageSizes.length;
+    index++
+  ) {
+    const size = mediaImageSizes[index].name;
+
+    const image = media.sizes[size];
+    if (image && image.filename) return image;
+  }
+
+  // if no larger size is available, return the next smaller size
+  for (let index = preferredSizeIndex - 1; index >= 0; index--) {
+    const size = mediaImageSizes[index].name;
+
+    const image = media.sizes[size];
+    if (image && image.filename) return image;
+  }
+
+  return media;
+}


### PR DESCRIPTION
## Problem

Closes #37.

Payload already stores multiple generated image sizes, and the frontend selected an appropriate stored size before handing the URL to ImageKit. However, fixed-size/object-cover layouts still downloaded images whose dimensions did not match the rendered area, wasting bandwidth and potentially increasing ImageKit transformation cost.

## What Changed

- Added responsive ImageKit crop source generation with `srcSet` support.
- Kept ImageKit transforms based on the selected Payload-generated image size, falling back to the original only when no generated size is available.
- Clamped crop candidates to the selected source image dimensions so ImageKit is not asked to upscale low-resolution sources.
- Opted only fixed-box/object-cover images into centered crops: about portrait, photo strip, and header avatar.
- Left logos and rich-text/media-block images uncropped to avoid damaging artwork or editorial content.
- Added unit coverage for URL generation, crop dimensions, source-size clamping, and Payload size selection.

## Validation

- `pnpm generate:types`
- `CI=true pnpm --filter @fxmk/frontend test`
- `pnpm --filter @fxmk/frontend exec vitest run app/utils/imagekit.test.ts`
- `pnpm --filter @fxmk/frontend typecheck`
- `pnpm --filter @fxmk/frontend lint --max-warnings=0`
- `pnpm --filter @fxmk/frontend check-format`
- GitHub Actions: latest PR checks passed, including frontend unit tests, lint, typecheck, builds, and e2e.

## Risks and Mitigations

- Risk: cropped images could change visual framing. Mitigation: crop is opt-in only for fixed object-cover layouts that already crop visually in CSS.
- Risk: low-resolution selected sources could be upscaled. Mitigation: `srcSet` candidates are clamped to the selected source width and height-derived crop limit.
- Risk: generated Payload types are unavailable in a fresh frontend-only unit-test run. Mitigation: unit-tested image selection uses a structural helper that does not import generated Payload types.

## Follow-ups / Known Limitations

- Rich-text and generic media-block images remain uncropped intentionally; they can opt in later if a specific fixed layout needs it.
- Crop focus is centered for now. Subject-aware or focal-point-aware cropping can be added later if the CMS/front-end contract needs it.