### PR TITLE
build(docker): improve app image caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,10 +116,6 @@ jobs:
           version: ${{ env.FLYCTL_VERSION }}
       - name: Setup
         uses: ./.github/actions/setup
-      - name: Set version on frontend
-        run: |
-          pnpm version ${{ needs.version.outputs.version }} --git-tag-version false
-        working-directory: apps/frontend
       - name: Download CMS types
         uses: actions/download-artifact@v4
         with:
@@ -139,6 +135,7 @@ jobs:
             --app ${{ steps.image-name.outputs.image_name }} \
             --config apps/frontend/fly.build.toml \
             --build-only \
+            --build-arg APP_VERSION=${{ needs.version.outputs.version }} \
             --image-label ${{ steps.image-name.outputs.image_tag }} \
             --label org.opencontainers.image.version=${{ steps.image-name.outputs.image_tag }} \
             --push \
@@ -186,10 +183,6 @@ jobs:
           version: ${{ env.FLYCTL_VERSION }}
       - name: Setup
         uses: ./.github/actions/setup
-      - name: Set version on CMS
-        run: |
-          pnpm version ${{ needs.version.outputs.version }} --git-tag-version false
-        working-directory: apps/cms
       - name: Get CMS image name
         id: image-name
         run: |
@@ -204,6 +197,7 @@ jobs:
             --app ${{ steps.image-name.outputs.image_name }} \
             --config apps/cms/fly.build.toml \
             --build-only \
+            --build-arg APP_VERSION=${{ needs.version.outputs.version }} \
             --image-label ${{ steps.image-name.outputs.image_tag }} \
             --label org.opencontainers.image.version=${{ steps.image-name.outputs.image_tag }} \
             --push \

--- a/apps/cms/Dockerfile
+++ b/apps/cms/Dockerfile
@@ -32,6 +32,7 @@ COPY --link libs/shared libs/shared
 # Uncomment the following line in case you want to disable telemetry during the build.
 # ENV NEXT_TELEMETRY_DISABLED 1
 
+RUN cp apps/cms/package.json /tmp/cms-package.json
 ARG APP_VERSION=0.0.0-unknown
 RUN node -e "const fs=require('node:fs'); const file='apps/cms/package.json'; const pkg=JSON.parse(fs.readFileSync(file,'utf8')); pkg.version=process.env.APP_VERSION; fs.writeFileSync(file, JSON.stringify(pkg, null, 2)+'\n');"
 
@@ -39,6 +40,7 @@ RUN cd apps/cms && \
     NODE_OPTIONS=--no-deprecation ./node_modules/.bin/payload generate:types && \
     NODE_OPTIONS=--no-deprecation ./node_modules/.bin/next build
 RUN node -e "const fs=require('node:fs'); const file='apps/cms/.next/standalone/apps/cms/package.json'; const pkg=JSON.parse(fs.readFileSync(file,'utf8')); pkg.version=process.env.APP_VERSION; fs.writeFileSync(file, JSON.stringify(pkg, null, 2)+'\n');"
+RUN cp /tmp/cms-package.json apps/cms/package.json
 
 # Production image, copy all the files and run next
 FROM base AS runner

--- a/apps/cms/Dockerfile
+++ b/apps/cms/Dockerfile
@@ -1,3 +1,5 @@
+# syntax = docker/dockerfile:1
+
 # From https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
 
 FROM node:24-alpine AS base
@@ -16,16 +18,27 @@ RUN corepack enable pnpm
 
 # Install dependencies
 COPY --link package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY --link apps/cms/package.json apps/cms/
+COPY --link libs/shared/package.json libs/shared/
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm --filter @fxmk/cms install --frozen-lockfile --store-dir=/pnpm/store
+
+# Copy application code
 COPY --link apps/cms apps/cms
 COPY --link libs/shared libs/shared
-RUN pnpm --filter cms install --frozen-lockfile
 
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry during the build.
 # ENV NEXT_TELEMETRY_DISABLED 1
 
-RUN pnpm --dir apps/cms build
+ARG APP_VERSION=0.0.0-unknown
+RUN node -e "const fs=require('node:fs'); const file='apps/cms/package.json'; const pkg=JSON.parse(fs.readFileSync(file,'utf8')); pkg.version=process.env.APP_VERSION; fs.writeFileSync(file, JSON.stringify(pkg, null, 2)+'\n');"
+
+RUN cd apps/cms && \
+    NODE_OPTIONS=--no-deprecation ./node_modules/.bin/payload generate:types && \
+    NODE_OPTIONS=--no-deprecation ./node_modules/.bin/next build
+RUN node -e "const fs=require('node:fs'); const file='apps/cms/.next/standalone/apps/cms/package.json'; const pkg=JSON.parse(fs.readFileSync(file,'utf8')); pkg.version=process.env.APP_VERSION; fs.writeFileSync(file, JSON.stringify(pkg, null, 2)+'\n');"
 
 # Production image, copy all the files and run next
 FROM base AS runner

--- a/apps/cms/fly.template.toml
+++ b/apps/cms/fly.template.toml
@@ -19,7 +19,7 @@ primary_region = '$FLY_PRIMARY_REGION'
   cpus = $FLY_CPUS
   
 [deploy]
-  release_command = "pnpm --filter cms payload migrate"
+  release_command = "sh -c 'cd /app/apps/cms && NODE_OPTIONS=--no-deprecation ./node_modules/.bin/payload migrate'"
 
 [env]
   MEDIA_S3_REGION = '$MEDIA_S3_REGION'

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -28,18 +28,27 @@ RUN apt-get update -qq && \
 # Install node modules
 COPY --link package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY --link apps/frontend/package.json apps/frontend/
-RUN pnpm --filter frontend install --prod=false --frozen-lockfile
+COPY --link libs/shared/package.json libs/shared/
+COPY --link libs/payload-types/package.json libs/payload-types/
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm --filter @fxmk/frontend install --prod=false --frozen-lockfile --store-dir=/pnpm/store
 
 # Copy application code
 COPY --link apps/frontend apps/frontend
 COPY --link libs/shared libs/shared
 COPY --link libs/payload-types libs/payload-types
 
+RUN cp apps/frontend/package.json /tmp/frontend-package.json
+ARG APP_VERSION=0.0.0-unknown
+RUN node -e "const fs=require('node:fs'); const file='apps/frontend/package.json'; const pkg=JSON.parse(fs.readFileSync(file,'utf8')); pkg.version=process.env.APP_VERSION; fs.writeFileSync(file, JSON.stringify(pkg, null, 2)+'\n');"
+
 # Build application
-RUN pnpm --filter frontend build
+RUN cd apps/frontend && ./node_modules/.bin/react-router build
 
 # Remove development dependencies
-RUN pnpm --dir apps/frontend prune --prod
+RUN cp /tmp/frontend-package.json apps/frontend/package.json
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm config set store-dir /pnpm/store && pnpm --dir apps/frontend prune --prod
 
 
 # Final stage for app image
@@ -47,7 +56,8 @@ FROM base
 
 # Copy built application
 COPY --from=build /app /app
+WORKDIR /app/apps/frontend
 
 # Start the server by default, this can be overwritten at runtime
 EXPOSE 3000
-CMD [ "pnpm", "--filter", "frontend", "start" ]
+CMD [ "./node_modules/.bin/react-router-serve", "./build/server/index.js" ]


### PR DESCRIPTION
## Summary

- split Docker dependency install layers from app/source copies for frontend and CMS
- use BuildKit cache mounts for the pnpm store during Docker dependency installs and frontend production pruning
- pass release versions through `APP_VERSION` build args instead of mutating checked-out package manifests in CI
- keep generated versions available in the React Router `/version` build and the CMS Next standalone package
- run the CMS Fly release migration through the installed Payload binary instead of pnpm, avoiding runtime deps checks under `/app`

## Context

The previous workflow mutated app `package.json` files before Docker builds, which invalidated source layers and made Docker dependency caching less useful. React Router and Payload/Next both read app package metadata during build, so the Dockerfiles now inject `APP_VERSION` after dependency install layers but before app build layers.

The CMS runtime still needs `payload migrate` during Fly deploys. Because pnpm performs a dependency status check before running package commands, the release command now calls the installed Payload binary directly from `/app/apps/cms`.

## Validation

- `pnpm check-format`
- `DOCKER_BUILDKIT=1 docker build -f apps/frontend/Dockerfile --build-arg APP_VERSION=9.9.9-test -t fxmk-frontend:test .`
- frontend image smoke test: `GET /version` returned `{"version":"9.9.9-test"}`
- `DOCKER_BUILDKIT=1 docker build -f apps/cms/Dockerfile --build-arg APP_VERSION=9.9.9-test -t fxmk-cms:test .`
- CMS image inspection confirmed `apps/cms/.next/standalone/apps/cms/package.json` version is `9.9.9-test`
- latest GitHub Actions run is green, including CMS/Frontend build-and-push, preview deploys, and e2e: https://github.com/fxmkdev/website/actions/runs/27159483871

## Risks and Mitigations

- Frontend and CMS version imports are build-time sensitive; both image builds were verified with a synthetic `APP_VERSION`.
- CMS Fly release migrations no longer go through pnpm; the direct Payload binary path was smoke-tested locally and the preview CMS deploy passed in CI.
- Docker reported the existing shell-form `CMD` warning for the CMS image; this PR leaves that unrelated runtime command unchanged.